### PR TITLE
Not sure if this is still maintained.  Tiny fix to add STATIC_URL to the templatetag context.  Thanks!

### DIFF
--- a/pagination/templatetags/pagination_tags.py
+++ b/pagination/templatetags/pagination_tags.py
@@ -205,6 +205,7 @@ def paginate(context, window=DEFAULT_WINDOW, hashtag=''):
             differenced.sort()
             pages.extend(differenced)
         to_return = {
+            'STATIC_URL': settings.STATIC_URL,
             'MEDIA_URL': settings.MEDIA_URL,
             'pages': pages,
             'records': records,


### PR DESCRIPTION
Pass STATIC_URL to templatetag context as per new convention in Django 1.3
